### PR TITLE
Add gettext to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Enable or disable do not disturb mode.
 Required dependencies to build on debian platforms are
 
 ```
-libglib2.0-bin gjs
+libglib2.0-bin gjs gettext
 ```
 
 To install, clone this repo and use make to install


### PR DESCRIPTION
I needed this for the `msgfmt` command when running `make`.